### PR TITLE
fix/prod-send-email

### DIFF
--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -61,8 +61,13 @@ export async function POST(request: NextRequest) {
       timezone,
     );
 
-    // Fire-and-forget admin notification
-    emailService.sendAdminNotification(booking).catch(console.error);
+    // Await admin notification to ensure it completes before the serverless function terminates
+    try {
+      await emailService.sendAdminNotification(booking);
+    } catch (error) {
+      console.error("Failed to send admin notification:", error);
+      // We don't throw here to avoid failing the booking if only the email fails
+    }
 
     return NextResponse.json({ booking }, { status: 201 });
   } catch (error: any) {


### PR DESCRIPTION
This pull request updates the handling of admin notification emails in the booking API route to ensure that the notification is sent before the serverless function completes. Instead of sending the email in a fire-and-forget manner, the function now awaits the completion of the email sending process and logs any errors that occur, without causing the booking to fail if the email fails.

Error handling and reliability improvements:

* Changed the admin notification email in `POST` of `src/app/api/booking/route.ts` to be awaited, ensuring the email is sent before function termination. Errors are now caught and logged, but do not cause the booking to fail if the email fails to send.