### PR TITLE
feat: add privacy and terms page

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,144 @@
+import React from "react";
+
+export const metadata = {
+  title: "Privacy Policy | Stackd",
+  description:
+    "Privacy Policy for Stackd services and Google OAuth integration.",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-white px-6 py-20 font-sans text-neutral-900 selection:bg-neutral-100">
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-16 border-b border-neutral-100 pb-10">
+          <h1 className="mb-3 text-4xl font-semibold tracking-tight text-neutral-950">
+            Privacy Policy
+          </h1>
+          <p className="text-sm text-neutral-500 italic">
+            Last updated: March 8, 2026
+          </p>
+        </header>
+
+        <div className="space-y-12">
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              1. Introduction
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              At Stackd, we respect your privacy and are committed to protecting
+              it. This Privacy Policy explains how we collect, use, and process
+              your data when you use our booking services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              2. Information We Collect via Google APIs
+            </h2>
+            <p className="mb-6 leading-relaxed text-neutral-600">
+              When you use our booking system, we access specific information
+              from Google APIs to facilitate your appointment:
+            </p>
+            <div className="space-y-6 border-l border-neutral-100 pl-4">
+              <div>
+                <h3 className="mb-1 text-sm font-semibold text-neutral-800">
+                  Email Address
+                </h3>
+                <p className="text-[15px] leading-relaxed text-neutral-600">
+                  We use Google OAuth to verify your email address to ensure the
+                  booking belongs to you.
+                </p>
+              </div>
+              <div>
+                <h3 className="mb-1 text-sm font-semibold text-neutral-800">
+                  Calendar Data
+                </h3>
+                <p className="text-[15px] leading-relaxed text-neutral-600">
+                  Our application uses a dedicated administrative Google
+                  Calendar to manage bookings. When you book a slot, we create
+                  an event on this calendar and add your email as an attendee so
+                  you receive a calendar invitation and a Google Meet link.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              3. How We Use This Data
+            </h2>
+            <p className="mb-4 leading-relaxed text-neutral-600">
+              We use your Google data solely for the following purposes:
+            </p>
+            <ul className="ml-5 list-outside list-disc space-y-3 text-neutral-600">
+              <li>To confirm your identity via Google Sign-In.</li>
+              <li>
+                To schedule your appointment and send you automated calendar
+                invites and reminders.
+              </li>
+            </ul>
+            <p className="mt-6 bg-neutral-50 p-4 text-[13px] leading-relaxed text-neutral-500">
+              <strong>Data Sharing Disclosure:</strong> We do not sell, trade,
+              or share your Google user data with any third parties. We do not
+              use this data for marketing purposes without your explicit
+              consent.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              4. Limited Use Disclosure
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              Stackd&apos;s use and transfer to any other app of information
+              received from Google APIs will adhere to the{" "}
+              <a
+                href="https://developers.google.com/terms/api-services-user-data-policy"
+                className="text-neutral-950 underline decoration-neutral-300 underline-offset-4 transition-colors hover:decoration-neutral-900"
+              >
+                Google API Service User Data Policy
+              </a>
+              , including the Limited Use requirements.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              5. Your Rights & Revoking Access
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              You can revoke our application&apos;s access to your Google
+              account at any time through your{" "}
+              <a
+                href="https://myaccount.google.com/permissions"
+                className="text-neutral-950 underline decoration-neutral-300 underline-offset-4 transition-colors hover:decoration-neutral-900"
+              >
+                Google Security Settings
+              </a>
+              .
+            </p>
+          </section>
+
+          <section className="border-t border-neutral-100 pt-12">
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              6. Contact Information
+            </h2>
+            <p className="mb-2 text-neutral-600">
+              If you have any questions regarding this Privacy Policy or our use
+              of Google APIs, please contact our support team:
+            </p>
+            <p className="font-medium text-neutral-950">
+              stackdcommerce@gmail.com
+            </p>
+          </section>
+        </div>
+
+        <footer className="mt-24 border-t border-neutral-100 pt-8 text-center">
+          <p className="text-xs font-medium tracking-widest text-neutral-400 uppercase">
+            &copy; 2026 Stackd. All rights reserved.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+
+export const metadata = {
+  title: "Terms of Service | Stackd",
+  description: "Terms of Service for Stackd booking platform.",
+};
+
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-screen bg-white px-6 py-20 font-sans text-neutral-900 selection:bg-neutral-100">
+      <div className="mx-auto max-w-2xl">
+        <header className="mb-16 border-b border-neutral-100 pb-10">
+          <h1 className="mb-3 text-4xl font-semibold tracking-tight text-neutral-950">
+            Terms of Service
+          </h1>
+          <p className="text-sm text-neutral-500 italic">
+            Last updated: March 8, 2026
+          </p>
+        </header>
+
+        <div className="space-y-12">
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              1. Acceptance of Terms
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              By accessing or using the Stackd booking service, you agree to be
+              bound by these Terms of Service. If you do not agree to these
+              terms, please do not use our services.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              2. Description of Service
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              Stackd provides an automated booking and appointment scheduling
+              platform. Our service integrates with Google APIs to manage
+              appointments on our administrative calendar and send you relevant
+              invitations and notifications.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              3. User Responsibilities
+            </h2>
+            <p className="mb-6 leading-relaxed text-neutral-600">
+              When using Stackd, you agree to:
+            </p>
+            <ul className="ml-5 list-outside list-disc space-y-3 text-neutral-600">
+              <li>
+                Provide accurate information (name and email) for bookings.
+              </li>
+              <li>
+                Use the service in accordance with applicable laws and
+                regulations.
+              </li>
+              <li>
+                Not attempt to disrupt or interfere with the security or
+                operation of the service.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              4. Google API Integration
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              Our service relies on Google OAuth for identity verification. By
+              using this feature, you also agree to Google&apos;s Terms of
+              Service and Privacy Policy. We are not responsible for any issues
+              arising from Google&apos;s own infrastructure or data handling
+              outside of our application.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              5. Limitation of Liability
+            </h2>
+            <p className="leading-relaxed text-neutral-600">
+              Stackd is provided &quot;as is&quot; without any warranties. We
+              shall not be liable for any indirect, incidental, or consequential
+              damages resulting from the use or inability to use our services.
+            </p>
+          </section>
+
+          <section className="border-t border-neutral-100 pt-12">
+            <h2 className="mb-4 text-lg font-semibold text-neutral-950">
+              6. Contact Information
+            </h2>
+            <p className="mb-2 text-neutral-600">
+              For any questions regarding these Terms, please reach out to us
+              at:
+            </p>
+            <p className="font-medium text-neutral-950">
+              stackdcommerce@gmail.com
+            </p>
+          </section>
+        </div>
+
+        <footer className="mt-24 border-t border-neutral-100 pt-8 text-center">
+          <p className="text-xs font-medium tracking-widest text-neutral-400 uppercase">
+            &copy; 2026 Stackd. All rights reserved.
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request adds dedicated pages for the Privacy Policy and Terms of Service to the application. These pages provide users with clear information about data handling, Google API integration, user responsibilities, and contact details.

New legal and policy documentation:

* Added a new `PrivacyPolicyPage` in `src/app/privacy/page.tsx` that outlines how user data is collected, used, and protected, especially regarding Google OAuth and Calendar integration. The page also explains users' rights and includes contact information.
* Added a new `TermsOfServicePage` in `src/app/terms/page.tsx` that details the terms of using the Stackd booking platform, including user responsibilities, Google API integration requirements, limitation of liability, and contact information.