### PR TITLE
feat: add rate limiter to booking

### DIFF
--- a/src/app/api/booking/available/route.ts
+++ b/src/app/api/booking/available/route.ts
@@ -1,28 +1,39 @@
 import { bookingModuleController } from "@/features/Booking/BookingModule";
 import { NextRequest, NextResponse } from "next/server";
+import { createRegularHandler } from "@/lib/api/createHandler";
 
-export async function GET(request: NextRequest) {
-  try {
-    const searchParams = request.nextUrl.searchParams;
-    const dateStr = searchParams.get("date");
-    const timezone = searchParams.get("timezone") ?? "UTC";
+export const GET = createRegularHandler(
+  async (request: NextRequest) => {
+    try {
+      const searchParams = request.nextUrl.searchParams;
+      const dateStr = searchParams.get("date");
+      const timezone = searchParams.get("timezone") ?? "UTC";
 
-    if (!dateStr) {
+      if (!dateStr) {
+        return NextResponse.json(
+          { error: "Date parameter is required" },
+          { status: 400 },
+        );
+      }
+
+      const availableSlots = await bookingModuleController.getAvailableSlots(
+        dateStr,
+        timezone,
+      );
+
+      return NextResponse.json({ slots: availableSlots }, { status: 200 });
+    } catch (error: any) {
+      console.error("GetAvailableSlots Error:", error);
       return NextResponse.json(
-        { error: "Date parameter is required" },
-        { status: 400 },
+        { error: error.message || "Internal Server Error" },
+        { status: 500 },
       );
     }
-
-    const availableSlots =
-      await bookingModuleController.getAvailableSlots(dateStr, timezone);
-
-    return NextResponse.json({ slots: availableSlots }, { status: 200 });
-  } catch (error: any) {
-    console.error("GetAvailableSlots Error:", error);
-    return NextResponse.json(
-      { error: error.message || "Internal Server Error" },
-      { status: 500 },
-    );
-  }
-}
+  },
+  {
+    limiter: {
+      requestPerDuration: 30,
+      durationSeconds: 60,
+    },
+  },
+);

--- a/src/app/api/booking/route.ts
+++ b/src/app/api/booking/route.ts
@@ -2,84 +2,103 @@ import { bookingModuleController } from "@/features/Booking/BookingModule";
 import { emailService } from "@/features/Booking/services/EmailService";
 import { NextRequest, NextResponse } from "next/server";
 import { OAuth2Client } from "google-auth-library";
+import { configs } from "@/configs/configs";
+import { createRegularHandler } from "@/lib/api/createHandler";
 
-export async function POST(request: NextRequest) {
-  try {
-    const authHeader = request.headers.get("Authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return NextResponse.json(
-        { error: "Unauthorized. Missing or invalid Authorization header." },
-        { status: 401 },
-      );
-    }
-    const token = authHeader.split(" ")[1];
-
-    let userEmail: string | undefined;
+export const POST = createRegularHandler(
+  async (request: NextRequest) => {
     try {
-      const client = new OAuth2Client();
-      const tokenInfo = await client.getTokenInfo(token);
-      userEmail = tokenInfo.email;
-    } catch (error) {
+      const authHeader = request.headers.get("Authorization");
+      if (!authHeader?.startsWith("Bearer ")) {
+        return NextResponse.json(
+          { error: "Unauthorized. Missing or invalid Authorization header." },
+          { status: 401 },
+        );
+      }
+      const token = authHeader.split(" ")[1];
+
+      let userEmail: string | undefined;
+      try {
+        const client = new OAuth2Client(configs.googleAuth.clientId);
+        const tokenInfo = await client.getTokenInfo(token);
+
+        // Verify the token was issued for our Client ID
+        if (tokenInfo.aud !== configs.googleAuth.clientId) {
+          return NextResponse.json(
+            { error: "Unauthorized. Token audience mismatch." },
+            { status: 401 },
+          );
+        }
+
+        userEmail = tokenInfo.email;
+      } catch (error) {
+        return NextResponse.json(
+          { error: "Unauthorized. Invalid Google token." },
+          { status: 401 },
+        );
+      }
+
+      if (!userEmail) {
+        return NextResponse.json(
+          { error: "Unauthorized. Could not read email from token." },
+          { status: 401 },
+        );
+      }
+
+      const { name, email, startTime, timezone } = await request.json();
+
+      if (!name || !email || !startTime || !timezone) {
+        return NextResponse.json(
+          { error: "Name, email, startTime, and timezone are required" },
+          { status: 400 },
+        );
+      }
+
+      // Verify email match (form vs OAuth)
+      if (email.toLowerCase() !== userEmail.toLowerCase()) {
+        return NextResponse.json(
+          {
+            error:
+              "Email mismatch. The email entered in the form does not match your Google account. Please use the same email.",
+          },
+          { status: 400 },
+        );
+      }
+
+      // Force the email to be the authenticated user's email
+      const booking = await bookingModuleController.createBooking(
+        name,
+        userEmail,
+        startTime,
+        timezone,
+      );
+
+      // Await admin notification to ensure it completes before the serverless function terminates
+      try {
+        await emailService.sendAdminNotification(booking);
+      } catch (error) {
+        console.error("Failed to send admin notification:", error);
+        // We don't throw here to avoid failing the booking if only the email fails
+      }
+
+      return NextResponse.json({ booking }, { status: 201 });
+    } catch (error: any) {
+      console.error(
+        "CreateBooking Full Error Object:",
+        JSON.stringify(error, null, 2),
+      );
+      console.error("CreateBooking Error Message:", error.message);
+
       return NextResponse.json(
-        { error: "Unauthorized. Invalid Google token." },
-        { status: 401 },
+        { error: error.message || "Internal Server Error" },
+        { status: 500 },
       );
     }
-
-    if (!userEmail) {
-      return NextResponse.json(
-        { error: "Unauthorized. Could not read email from token." },
-        { status: 401 },
-      );
-    }
-
-    const { name, email, startTime, timezone } = await request.json();
-
-    if (!name || !email || !startTime || !timezone) {
-      return NextResponse.json(
-        { error: "Name, email, startTime, and timezone are required" },
-        { status: 400 },
-      );
-    }
-
-    // Verify email match (form vs OAuth)
-    if (email.toLowerCase() !== userEmail.toLowerCase()) {
-      return NextResponse.json(
-        {
-          error:
-            "Email mismatch. The email entered in the form does not match your Google account. Please use the same email.",
-        },
-        { status: 400 },
-      );
-    }
-
-    // Force the email to be the authenticated user's email
-    const booking = await bookingModuleController.createBooking(
-      name,
-      userEmail,
-      startTime,
-      timezone,
-    );
-
-    // Await admin notification to ensure it completes before the serverless function terminates
-    try {
-      await emailService.sendAdminNotification(booking);
-    } catch (error) {
-      console.error("Failed to send admin notification:", error);
-      // We don't throw here to avoid failing the booking if only the email fails
-    }
-
-    return NextResponse.json({ booking }, { status: 201 });
-  } catch (error: any) {
-    console.error(
-      "CreateBooking Full Error Object:",
-      JSON.stringify(error, null, 2),
-    );
-    console.error("CreateBooking Error Message:", error.message);
-
-    return NextResponse.json(
-      { error: error.message || "Internal Server Error" },
-      { status: 500 },
-    );
-  }
-}
+  },
+  {
+    limiter: {
+      requestPerDuration: 5,
+      durationSeconds: 60,
+    },
+  },
+);


### PR DESCRIPTION
This pull request refactors the API route handlers for booking-related endpoints to use a new `createRegularHandler` utility, adds rate limiting to both endpoints, and strengthens Google authentication verification in the booking creation endpoint.

**API handler refactoring and enhancements:**

* Refactored the `GET` handler in `src/app/api/booking/available/route.ts` and the `POST` handler in `src/app/api/booking/route.ts` to use the `createRegularHandler` utility, improving consistency and maintainability of API route definitions. [[1]](diffhunk://#diff-4fa343178538217f759f19db23446df7a1aa8fb41f2e8d8aae327fc2c5957efaR3-R6) [[2]](diffhunk://#diff-122c774eb05ce92410f28b528cab356d1571ddad58f88693d84c126d108c7cb4R5-R9)

**Rate limiting:**

* Added rate limiting to the booking availability endpoint (`GET /api/booking/available`) with a limit of 30 requests per 60 seconds.
* Added rate limiting to the booking creation endpoint (`POST /api/booking`) with a limit of 5 requests per 60 seconds.

**Authentication improvements:**

* Enhanced Google authentication in the booking creation endpoint by initializing `OAuth2Client` with the configured client ID and explicitly verifying that the token's audience matches the expected client ID, improving security against token misuse.

Closes #73 