### PR TITLE
fix(oauth): resolve the infinite loading in oauth error

### DIFF
--- a/src/features/Booking/hooks/useCalendarBooking.ts
+++ b/src/features/Booking/hooks/useCalendarBooking.ts
@@ -58,6 +58,10 @@ export function useCalendarBooking() {
       );
       setSubmitting(false);
     },
+    onNonOAuthError: (error) => {
+      console.log("Google login cancelled or failed:", error);
+      setSubmitting(false);
+    },
   });
 
   const handleDateSelect = async (date: Date | undefined) => {


### PR DESCRIPTION
This pull request introduces improved error handling for Google login failures in the `useCalendarBooking` hook. Now, if a non-OAuth error occurs (such as the user cancelling the login or a failure in the process), the error is logged and the submitting state is reset to ensure the UI responds appropriately.

Closes #83 

<img width="1266" height="706" alt="image" src="https://github.com/user-attachments/assets/85c2e288-012b-463b-adb2-faf5cb33d851" />
<img width="1115" height="575" alt="image" src="https://github.com/user-attachments/assets/618d940d-3058-4592-83d5-066c69871fbb" />
