### PR TITLE
feat: add caching for the database calls

### DIFF
--- a/src/app/api/certifications/[certificationId]/route.ts
+++ b/src/app/api/certifications/[certificationId]/route.ts
@@ -5,6 +5,7 @@ import {
   NotFoundError,
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
+import { revalidatePath } from "next/cache";
 
 export const GET = createRegularHandler(
   async (
@@ -62,6 +63,8 @@ export const PATCH = createRegularHandler(
         rankingIndex,
       );
 
+    revalidatePath("/api/certifications");
+
     return NextResponse.json(
       {
         message: "Certification updated successfully",
@@ -88,6 +91,8 @@ export const DELETE = createRegularHandler(
       await certificationsModuleController.deleteCertification(certificationId);
 
     if (!data) throw new NotFoundError("Resource not found");
+
+    revalidatePath("/api/certifications");
 
     return NextResponse.json(
       { message: "ok", status: "success" },

--- a/src/app/api/certifications/route.ts
+++ b/src/app/api/certifications/route.ts
@@ -5,6 +5,9 @@ import {
   BadRequestError,
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
+import { revalidatePath } from "next/cache";
+
+export const revalidate = 3600; // Revalidate every hour
 
 export const GET = createRegularHandler(async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
@@ -73,6 +76,8 @@ export const POST = createRegularHandler(
         description,
         image,
       );
+
+    revalidatePath("/api/certifications");
 
     return NextResponse.json(newCertification, { status: 201 });
   },

--- a/src/app/api/team-members/[teamMemberId]/route.ts
+++ b/src/app/api/team-members/[teamMemberId]/route.ts
@@ -5,6 +5,7 @@ import {
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 
 export const GET = createRegularHandler(
   async (
@@ -71,6 +72,8 @@ export const PATCH = createRegularHandler(
       rankingIndex,
     );
 
+    revalidatePath("/api/team-members");
+
     return NextResponse.json(
       { message: "Member updated successfully", data: updatedMember },
       { status: 200 },
@@ -94,6 +97,8 @@ export const DELETE = createRegularHandler(
       await teamMembersModuleController.deleteMember(teamMemberId);
 
     if (!data) throw new NotFoundError("Resource not found");
+
+    revalidatePath("/api/team-members");
 
     return NextResponse.json(
       { message: "ok", status: "success" },

--- a/src/app/api/team-members/route.ts
+++ b/src/app/api/team-members/route.ts
@@ -5,6 +5,9 @@ import {
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
 import { NextRequest, NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+
+export const revalidate = 3600; // Revalidate every hour
 
 export const GET = createRegularHandler(async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
@@ -114,6 +117,8 @@ export const POST = createRegularHandler(
       linkedinProfile || undefined,
       achievements,
     );
+
+    revalidatePath("/api/team-members");
 
     return NextResponse.json(newMember, { status: 201 });
   },

--- a/src/app/api/testimonials/[testimonialId]/route.ts
+++ b/src/app/api/testimonials/[testimonialId]/route.ts
@@ -5,6 +5,7 @@ import {
   NotFoundError,
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
+import { revalidatePath } from "next/cache";
 
 export const GET = createRegularHandler(
   async (
@@ -66,6 +67,8 @@ export const PATCH = createRegularHandler(
         newCompanyLogo || undefined,
       );
 
+    revalidatePath("/api/testimonials");
+
     return NextResponse.json(
       {
         message: "Testimonial updated successfully",
@@ -92,6 +95,8 @@ export const DELETE = createRegularHandler(
       await testimonialsModuleController.deleteTestimonial(testimonialId);
 
     if (!data) throw new NotFoundError("Resource not found");
+
+    revalidatePath("/api/testimonials");
 
     return NextResponse.json(
       { message: "ok", status: "success" },

--- a/src/app/api/testimonials/route.ts
+++ b/src/app/api/testimonials/route.ts
@@ -5,6 +5,9 @@ import {
   BadRequestError,
   UnprocessableEntityError,
 } from "@/lib/errors/HttpError";
+import { revalidatePath } from "next/cache";
+
+export const revalidate = 3600; // Revalidate every hour
 
 export const GET = createRegularHandler(async (request: NextRequest) => {
   const searchParams = request.nextUrl.searchParams;
@@ -78,6 +81,8 @@ export const POST = createRegularHandler(
       image,
       companyLogo || undefined,
     );
+
+    revalidatePath("/api/testimonials");
 
     return NextResponse.json(newTestimonial, { status: 201 });
   },


### PR DESCRIPTION
Implemented on-demand revalidation for all dynamic CMS sections (Team Members, Testimonials, and Certifications).

How it works now:
1. Efficiency: Database calls are cached for 1 hour by default to keep the site fast for visitors.
2. Instant Updates: Updated the CMS POST, PATCH, and DELETE handlers. The moment an entry is added, updated, or removed in the CMS, it calls revalidatePath.
3. The Result: a website "knows" exactly when data changes. The cache is immediately cleared for that specific section, and the next visitor will see the fresh data instantly.

Files Updated:
- src/app/api/team-members/route.ts & [teamMemberId]/route.ts
- src/app/api/testimonials/route.ts & [testimonialId]/route.ts
- src/app/api/certifications/route.ts & [certificationId]/route.ts

Closes #160